### PR TITLE
fix: change reset-requests endpoint method from POST to PATCH #36

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -611,7 +611,7 @@ const docTemplate = `{
             }
         },
         "/api/v1/environments/{id}/services/{service_id}/reset-requests": {
-            "post": {
+            "patch": {
                 "security": [
                     {
                         "OAuth2Password": []

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -603,7 +603,7 @@
             }
         },
         "/api/v1/environments/{id}/services/{service_id}/reset-requests": {
-            "post": {
+            "patch": {
                 "security": [
                     {
                         "OAuth2Password": []

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -639,7 +639,7 @@ paths:
       tags:
       - Environments
   /api/v1/environments/{id}/services/{service_id}/reset-requests:
-    post:
+    patch:
       description: Resets the available request count for a specific service within
         an environment
       parameters:

--- a/internal/adapters/http/handlers/environment.go
+++ b/internal/adapters/http/handlers/environment.go
@@ -225,7 +225,7 @@ func RemoveServiceFromEnvironment(environmentUseCase inbound.EnvironmentHTTPPort
 // @Param service_id path int true "Service ID"
 // @Success 200 {object} dto.EnvironmentServiceResponse
 // @Failure default {object} utils.ErrorResponse "Default error response for all failures"
-// @Router /api/v1/environments/{id}/services/{service_id}/reset-requests [post]
+// @Router /api/v1/environments/{id}/services/{service_id}/reset-requests [patch]
 func ResetServiceRequestsFromEnvironment(environmentUseCase inbound.EnvironmentHTTPPort) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		environmentID, paramErr := strconv.Atoi(c.Param("id"))

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -124,7 +124,7 @@ func (s *Server) setupRoutes(router *gin.RouterGroup) {
 				"/:id/services/:service_id",
 				handlers.RemoveServiceFromEnvironment(s.environmentService),
 			)
-			environments.POST(
+			environments.PATCH(
 				"/:id/services/:service_id/reset-requests",
 				handlers.ResetServiceRequestsFromEnvironment(s.environmentService),
 			)


### PR DESCRIPTION
## Summary

This PR fixes the incorrect HTTP method used in the `reset-requests` endpoint.

The method was updated from POST to PATCH to comply with the expected behavior.

Both the Swagger documentation and the Gin routing were updated accordingly.

## Changes

Manual changes were made in the following files:

* `internal/adapters/http/handlers/environment.go`
* `internal/adapters/http/server.go`

All other changes are auto-generated.

## Related Issue

Closes #36