### PR TITLE
Return full client entity after update in PATCH endpoint #25

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -322,8 +322,11 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ClientResponse"
+                        }
                     },
                     "default": {
                         "description": "Default error response for all failures",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -314,8 +314,11 @@
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ClientResponse"
+                        }
                     },
                     "default": {
                         "description": "Default error response for all failures",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -453,8 +453,10 @@ paths:
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ClientResponse'
         default:
           description: Default error response for all failures
           schema:

--- a/internal/adapters/http/handlers/client.go
+++ b/internal/adapters/http/handlers/client.go
@@ -127,7 +127,7 @@ func GetClient(clientService inbound.ClientHTTPPort) gin.HandlerFunc {
 // @Produce json
 // @Param id path int true "Client ID"
 // @Param request body dto.ClientUpdate true "Updated client data"
-// @Success 204
+// @Success 200 {object} dto.ClientResponse
 // @Failure default {object} utils.ErrorResponse "Default error response for all failures"
 // @Router /api/v1/clients/{id} [patch]
 func UpdateClient(clientService inbound.ClientHTTPPort) gin.HandlerFunc {
@@ -151,7 +151,7 @@ func UpdateClient(clientService inbound.ClientHTTPPort) gin.HandlerFunc {
 			return
 		}
 
-		err := clientService.Update(c.Request.Context(), clientID, &req)
+		client, err := clientService.Update(c.Request.Context(), clientID, &req)
 		if err != nil {
 			c.AbortWithStatusJSON(
 				utils.GetDomainErrorStatusCode(err),
@@ -160,7 +160,7 @@ func UpdateClient(clientService inbound.ClientHTTPPort) gin.HandlerFunc {
 			return
 		}
 
-		c.Status(http.StatusNoContent)
+		c.JSON(http.StatusOK, client)
 	}
 }
 

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -16,8 +16,19 @@ type ClientUseCase struct {
 
 func (u *ClientUseCase) Update(
 	ctx context.Context, id int, req *dto.ClientUpdate,
-) *errors.Error {
-	return u.clientRepo.Update(ctx, id, req)
+) (*dto.ClientResponse, *errors.Error) {
+	client, err := u.clientRepo.Update(ctx, id, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.ClientResponse{
+		ID:        client.ID,
+		Type:      client.Type,
+		Name:      client.Name,
+		Email:     client.Email,
+		CreatedAt: client.CreatedAt,
+	}, nil
 }
 
 func (u *ClientUseCase) GetByID(

--- a/internal/ports/inbound/client.go
+++ b/internal/ports/inbound/client.go
@@ -10,7 +10,7 @@ import (
 type ClientHTTPPort interface {
 	Create(ctx context.Context, req *dto.ClientCreate) (*dto.ClientResponse, *errors.Error)
 	GetAll(ctx context.Context, req *dto.ClientFilter) ([]*dto.ClientResponse, *errors.Error)
-	Update(ctx context.Context, id int, req *dto.ClientUpdate) *errors.Error
+	Update(ctx context.Context, id int, req *dto.ClientUpdate) (*dto.ClientResponse, *errors.Error)
 	GetByID(ctx context.Context, id int) (*dto.ClientResponse, *errors.Error)
 	GetProjects(ctx context.Context, id int) ([]*dto.ProjectResponse, *errors.Error)
 }

--- a/internal/ports/outbound/client.go
+++ b/internal/ports/outbound/client.go
@@ -11,7 +11,7 @@ import (
 type ClientPort interface {
 	Save(ctx context.Context, client *entities.Client) *errors.Error
 	Exists(ctx context.Context, id int) (bool, *errors.Error)
-	Update(ctx context.Context, id int, update *dto.ClientUpdate) *errors.Error
+	Update(ctx context.Context, id int, update *dto.ClientUpdate) (*entities.Client, *errors.Error)
 	FindAll(ctx context.Context, filter *dto.ClientFilter) ([]*entities.Client, *errors.Error)
 	FindByID(ctx context.Context, id int) (*entities.Client, *errors.Error)
 }


### PR DESCRIPTION
This PR updates the client repository to return the full client entity after a successful update using the RETURNING clause in the SQL query:

```sql
...
RETURNING id, type, name, email, created_at;
```

## Additional details:

* If no update fields are provided in the request, the handler falls back to a simple FindByID.
* Updated entity mapping logic to support the returned values.
* Improves consistency with API standards that require returning updated entities on PATCH.

---

Closes #25 