### PR TITLE
Implement PATCH `/api/v1/services/{id}/status` endpoint #22

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -906,7 +906,8 @@ const docTemplate = `{
                     {
                         "enum": [
                             "active",
-                            "deactivated"
+                            "deactivated",
+                            "deprecated"
                         ],
                         "type": "string",
                         "name": "status",
@@ -962,6 +963,58 @@ const docTemplate = `{
                 "responses": {
                     "201": {
                         "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ServiceResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/services/{id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Changes the current status of a specific service by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Updates the status of a service",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Service ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New service status",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ServiceStatusUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.ServiceResponse"
                         }
@@ -1344,11 +1397,25 @@ const docTemplate = `{
                     "type": "string",
                     "enum": [
                         "active",
-                        "deactivated"
+                        "deactivated",
+                        "deprecated"
                     ]
                 },
                 "version": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.ServiceStatusUpdate": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "deactivated",
+                        "deprecated"
+                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -898,7 +898,8 @@
                     {
                         "enum": [
                             "active",
-                            "deactivated"
+                            "deactivated",
+                            "deprecated"
                         ],
                         "type": "string",
                         "name": "status",
@@ -954,6 +955,58 @@
                 "responses": {
                     "201": {
                         "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ServiceResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/services/{id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Changes the current status of a specific service by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Updates the status of a service",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Service ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New service status",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ServiceStatusUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.ServiceResponse"
                         }
@@ -1336,11 +1389,25 @@
                     "type": "string",
                     "enum": [
                         "active",
-                        "deactivated"
+                        "deactivated",
+                        "deprecated"
                     ]
                 },
                 "version": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.ServiceStatusUpdate": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "active",
+                        "deactivated",
+                        "deprecated"
+                    ]
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -247,8 +247,18 @@ definitions:
         enum:
         - active
         - deactivated
+        - deprecated
         type: string
       version:
+        type: string
+    type: object
+  dto.ServiceStatusUpdate:
+    properties:
+      status:
+        enum:
+        - active
+        - deactivated
+        - deprecated
         type: string
     type: object
   utils.ErrorResponse:
@@ -821,6 +831,7 @@ paths:
       - enum:
         - active
         - deactivated
+        - deprecated
         in: query
         name: status
         type: string
@@ -867,6 +878,39 @@ paths:
       security:
       - OAuth2Password: []
       summary: Creates a new service
+      tags:
+      - Services
+  /api/v1/services/{id}/status:
+    patch:
+      consumes:
+      - application/json
+      description: Changes the current status of a specific service by ID
+      parameters:
+      - description: Service ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: New service status
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ServiceStatusUpdate'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ServiceResponse'
+        default:
+          description: Default error response for all failures
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+      security:
+      - OAuth2Password: []
+      summary: Updates the status of a service
       tags:
       - Services
 securityDefinitions:

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -72,6 +72,10 @@ func (s *Server) setupRoutes(router *gin.RouterGroup) {
 		{
 			services.GET("", handlers.GetAllServices(s.srvService))
 			services.POST("", handlers.CreateService(s.srvService))
+			services.PATCH(
+				"/:id/status",
+				handlers.UpdateStatusService(s.srvService),
+			)
 		}
 
 		clients := protected.Group("/clients")

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -14,6 +14,26 @@ type ServiceUseCase struct {
 	serviceRepo outbound.ServicePort
 }
 
+func (u *ServiceUseCase) UpdateStatus(
+	ctx context.Context, id int, status enums.ServiceStatus,
+) (*dto.ServiceResponse, *errors.Error) {
+	service, err := u.serviceRepo.UpdateStatus(ctx, id, status)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil, errors.ErrServiceNotFound
+		}
+		return nil, err
+	}
+
+	return &dto.ServiceResponse{
+		ID:        service.ID,
+		Name:      service.Name,
+		Status:    service.Status,
+		Version:   service.Version,
+		CreatedAt: service.CreatedAt,
+	}, nil
+}
+
 func (u *ServiceUseCase) GetServices(
 	ctx context.Context, req *dto.ServiceFilter,
 ) ([]*dto.ServiceResponse, *errors.Error) {

--- a/internal/domain/dto/service.go
+++ b/internal/domain/dto/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ServiceFilter struct {
-	Status enums.ServiceStatus `form:"status,omitempty" enums:"active,deactivated" swaggertype:"string"`
+	Status enums.ServiceStatus `form:"status,omitempty" enums:"active,deactivated,deprecated" swaggertype:"string"`
 }
 
 type ServiceCreate struct {
@@ -18,7 +18,11 @@ type ServiceCreate struct {
 type ServiceResponse struct {
 	ID        int                 `json:"id"`
 	Name      string              `json:"name"`
-	Status    enums.ServiceStatus `json:"status" enums:"active,deactivated" swaggertype:"string"`
+	Status    enums.ServiceStatus `json:"status" enums:"active,deactivated,deprecated" swaggertype:"string"`
 	Version   string              `json:"version"`
 	CreatedAt time.Time           `json:"created_at"`
+}
+
+type ServiceStatusUpdate struct {
+	Status enums.ServiceStatus `json:"status,omitempty" enums:"active,deactivated,deprecated" swaggertype:"string"`
 }

--- a/internal/ports/inbound/service.go
+++ b/internal/ports/inbound/service.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/MAD-py/pandora-core/internal/domain/dto"
+	"github.com/MAD-py/pandora-core/internal/domain/enums"
 	"github.com/MAD-py/pandora-core/internal/domain/errors"
 )
 
 type ServiceHTTPPort interface {
 	Create(ctx context.Context, req *dto.ServiceCreate) (*dto.ServiceResponse, *errors.Error)
 	GetServices(ctx context.Context, req *dto.ServiceFilter) ([]*dto.ServiceResponse, *errors.Error)
+	UpdateStatus(ctx context.Context, id int, status enums.ServiceStatus) (*dto.ServiceResponse, *errors.Error)
 }

--- a/internal/ports/outbound/service.go
+++ b/internal/ports/outbound/service.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/MAD-py/pandora-core/internal/domain/dto"
 	"github.com/MAD-py/pandora-core/internal/domain/entities"
+	"github.com/MAD-py/pandora-core/internal/domain/enums"
 	"github.com/MAD-py/pandora-core/internal/domain/errors"
 )
 
 type ServicePort interface {
 	Save(ctx context.Context, service *entities.Service) *errors.Error
+	UpdateStatus(ctx context.Context, id int, status enums.ServiceStatus) (*entities.Service, *errors.Error)
 	FindAll(ctx context.Context, filter *dto.ServiceFilter) ([]*entities.Service, *errors.Error)
 }
 


### PR DESCRIPTION
This PR implements the PATCH `/api/v1/services/{id}/status` endpoint to allow updating the status of a service.

## Changes included:

* Added `UpdateStatus` method in the service repository. It takes the service ID and new status, returning a specific error if the provided status is the default/null version.
* In the business logic layer, handled mapping of domain errors and transformed entity to DTO.
* Created a new DTO to map the request body (`{ "status": Enum }`).
* Implemented the HTTP handler to complete the endpoint flow.

## Behavior:

* Supports transitions between any statuses.
* If the requested status is the same as the current one, the update is processed without error.
* Returns the updated service object and a 200 OK response.

This endpoint improves service lifecycle management by allowing administrators to adjust availability and visibility of services in Pandora.

---

Closes #22 