### PR TITLE
Implement PATCH `/api/v1/environments/{id}` endpoint with name update and repository improvements

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -466,6 +466,56 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Modifies the details of a specific environment by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Updates an environment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Environment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated environment data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.EnvironmentUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.EnvironmentResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/environments/{id}/api-keys": {
@@ -1195,6 +1245,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.EnvironmentUpdate": {
+            "type": "object",
+            "properties": {
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -458,6 +458,56 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Modifies the details of a specific environment by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Updates an environment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Environment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated environment data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.EnvironmentUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.EnvironmentResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/environments/{id}/api-keys": {
@@ -1187,6 +1237,14 @@
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.EnvironmentUpdate": {
+            "type": "object",
+            "properties": {
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -146,6 +146,11 @@ definitions:
       version:
         type: string
     type: object
+  dto.EnvironmentUpdate:
+    properties:
+      name:
+        type: string
+    type: object
   dto.ProjectCreate:
     properties:
       client_id:
@@ -546,6 +551,38 @@ paths:
       security:
       - OAuth2Password: []
       summary: Retrieves an environment by ID
+      tags:
+      - Environments
+    patch:
+      consumes:
+      - application/json
+      description: Modifies the details of a specific environment by ID
+      parameters:
+      - description: Environment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated environment data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.EnvironmentUpdate'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.EnvironmentResponse'
+        default:
+          description: Default error response for all failures
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+      security:
+      - OAuth2Password: []
+      summary: Updates an environment
       tags:
       - Environments
   /api/v1/environments/{id}/api-keys:

--- a/internal/adapters/http/handlers/environment.go
+++ b/internal/adapters/http/handlers/environment.go
@@ -84,6 +84,53 @@ func GetEnvironment(environmentUseCase inbound.EnvironmentHTTPPort) gin.HandlerF
 	}
 }
 
+// UpdateEnvironment godoc
+// @Summary Updates an environment
+// @Description Modifies the details of a specific environment by ID
+// @Tags Environments
+// @Security OAuth2Password
+// @Accept json
+// @Produce json
+// @Param id path int true "Environment ID"
+// @Param request body dto.EnvironmentUpdate true "Updated environment data"
+// @Success 200 {object} dto.EnvironmentResponse
+// @Failure default {object} utils.ErrorResponse "Default error response for all failures"
+// @Router /api/v1/environments/{id} [patch]
+func UpdateEnvironment(environmentUseCase inbound.EnvironmentHTTPPort) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environmentID, paramErr := strconv.Atoi(c.Param("id"))
+		if paramErr != nil {
+			c.AbortWithStatusJSON(
+				http.StatusBadRequest,
+				gin.H{"error": "Invalid Environment ID"},
+			)
+			return
+		}
+
+		var req dto.EnvironmentUpdate
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(
+				utils.GetBindJSONErrorStatusCode(err),
+				gin.H{"error": err.Error()},
+			)
+			return
+		}
+
+		environment, err := environmentUseCase.Update(
+			c.Request.Context(), environmentID, &req,
+		)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				utils.GetDomainErrorStatusCode(err),
+				gin.H{"error": err.Error()},
+			)
+			return
+		}
+
+		c.JSON(http.StatusOK, environment)
+	}
+}
+
 // GetAPIKeysByEnvironment godoc
 // @Summary Retrieves all API Keys for an environment
 // @Description Returns a list of API Keys associated with a specific environment

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -112,6 +112,9 @@ func (s *Server) setupRoutes(router *gin.RouterGroup) {
 			environments.GET(
 				"/:id", handlers.GetEnvironment(s.environmentService),
 			)
+			environments.PATCH(
+				"/:id", handlers.UpdateEnvironment(s.environmentService),
+			)
 			environments.GET(
 				"/:id/api-keys",
 				handlers.GetAPIKeysByEnvironment(s.apiKeyService),

--- a/internal/adapters/persistence/repository/environment.go
+++ b/internal/adapters/persistence/repository/environment.go
@@ -112,9 +112,9 @@ func (r *EnvironmentRepository) UpdateStatus(
 
 func (r *EnvironmentRepository) Update(
 	ctx context.Context, id int, update *dto.EnvironmentUpdate,
-) *errors.Error {
+) (*entities.Environment, *errors.Error) {
 	if update == nil {
-		return nil
+		return r.FindByID(ctx, id)
 	}
 
 	var updates []string
@@ -128,7 +128,7 @@ func (r *EnvironmentRepository) Update(
 	}
 
 	if len(updates) == 0 {
-		return nil
+		return r.FindByID(ctx, id)
 	}
 
 	query := fmt.Sprintf(
@@ -142,14 +142,14 @@ func (r *EnvironmentRepository) Update(
 
 	result, err := r.pool.Exec(ctx, query, args...)
 	if err != nil {
-		return r.handlerErr(err)
+		return nil, r.handlerErr(err)
 	}
 
 	if result.RowsAffected() == 0 {
-		return errors.ErrEnvironmentNotFound
+		return nil, errors.ErrEnvironmentNotFound
 	}
 
-	return nil
+	return r.FindByID(ctx, id)
 }
 
 func (r *EnvironmentRepository) Exists(

--- a/internal/app/environment.go
+++ b/internal/app/environment.go
@@ -16,6 +16,38 @@ type EnvironmentUseCase struct {
 	projectRepo     outbound.ProjectPort
 }
 
+func (u *EnvironmentUseCase) Update(
+	ctx context.Context, id int, req *dto.EnvironmentUpdate,
+) (*dto.EnvironmentResponse, *errors.Error) {
+	environment, err := u.environmentRepo.Update(ctx, id, req)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResp := make(
+		[]*dto.EnvironmentServiceResponse, len(environment.Services),
+	)
+	for i, service := range environment.Services {
+		serviceResp[i] = &dto.EnvironmentServiceResponse{
+			ID:               service.ID,
+			Name:             service.Name,
+			Version:          service.Version,
+			MaxRequest:       service.MaxRequest,
+			AvailableRequest: service.AvailableRequest,
+			AssignedAt:       service.AssignedAt,
+		}
+	}
+
+	return &dto.EnvironmentResponse{
+		ID:        environment.ID,
+		Name:      environment.Name,
+		Status:    environment.Status,
+		ProjectID: environment.ProjectID,
+		CreatedAt: environment.CreatedAt,
+		Services:  serviceResp,
+	}, nil
+}
+
 func (u *EnvironmentUseCase) ResetServiceRequests(
 	ctx context.Context, id, serviceID int,
 ) (*dto.EnvironmentServiceResponse, *errors.Error) {

--- a/internal/ports/inbound/environment.go
+++ b/internal/ports/inbound/environment.go
@@ -9,6 +9,7 @@ import (
 
 type EnvironmentHTTPPort interface {
 	Create(ctx context.Context, req *dto.EnvironmentCreate) (*dto.EnvironmentResponse, *errors.Error)
+	Update(ctx context.Context, id int, req *dto.EnvironmentUpdate) (*dto.EnvironmentResponse, *errors.Error)
 	GetByID(ctx context.Context, id int) (*dto.EnvironmentResponse, *errors.Error)
 	RemoveService(ctx context.Context, id, serviceID int) *errors.Error
 	AssignService(ctx context.Context, id int, req *dto.EnvironmentService) *errors.Error

--- a/internal/ports/outbound/environment.go
+++ b/internal/ports/outbound/environment.go
@@ -11,7 +11,9 @@ import (
 type EnvironmentPort interface {
 	Save(ctx context.Context, environment *entities.Environment) *errors.Error
 	Exists(ctx context.Context, id int) (bool, *errors.Error)
+	Update(ctx context.Context, id int, update *dto.EnvironmentUpdate) (*entities.Environment, *errors.Error)
 	FindByID(ctx context.Context, id int) (*entities.Environment, *errors.Error)
+	IsActive(ctx context.Context, id int) (bool, *errors.Error)
 	AddService(ctx context.Context, id int, service *entities.EnvironmentService) *errors.Error
 	RemoveService(ctx context.Context, id, serviceID int) (int64, *errors.Error)
 	FindByProject(ctx context.Context, projectID int) ([]*entities.Environment, *errors.Error)
@@ -21,5 +23,4 @@ type EnvironmentPort interface {
 	GetProjectServiceQuotaUsage(ctx context.Context, id, serviceID int) (*dto.QuotaUsage, *errors.Error)
 	RemoveServiceFromProjectEnvironments(ctx context.Context, projectID, serviceID int) (int64, *errors.Error)
 	IncreaseAvailableRequest(ctx context.Context, id, serviceID int) *errors.Error
-	IsActive(ctx context.Context, id int) (bool, *errors.Error)
 }


### PR DESCRIPTION
This PR introduces support for updating general fields of an environment via the new PATCH `/api/v1/environments/{id} `HTTP endpoint, starting with the `name` field.

## Highlights:

* Created the HTTP handler and use case to handle partial updates to environments.
* Designed the logic to allow future extension with minimal changes when new fields become updatable.
* Implemented a repository method for updating the `environment` in the database.

## Repository Notes:

Initially, we attempted to use a single query with `WITH updated AS (...)` to both update and return the full environment object, including its associated services (through the `environment_service` join table). However, this approach caused issues during the `GROUP BY` clause. Because `updated` becomes a virtual temporary table, it loses certain metadata—like primary key constraints—making the aggregation and grouping logic unreliable in PostgreSQL.

Example of the attempted query:

```sql
WITH updated AS (
    UPDATE environment
    SET %s
    WHERE id = $1
    RETURNING *
)
SELECT u.id, u.name, u.status, u.project_id, u.created_at,
    COALESCE(
        JSON_AGG(
            JSON_BUILD_OBJECT(
                'id', s.id,
                'name', s.name,
                'version', s.version,
                'maxRequest', COALESCE(es.max_request, -1),
                'availableRequest', COALESCE(es.available_request, -1),
                'assignedAt', es.created_at
            )
        ), '[]'
    )
FROM (SELECT * FROM updated) u
LEFT JOIN environment_service es ON u.id = es.environment_id
LEFT JOIN service s ON s.id = es.service_id
GROUP BY u.id;
```

Instead, after validating and testing different approaches, we opted to perform the update first, then do a `findByID` query if the update was successful. This approach was cleaner and more maintainable given the current complexity of resolving the many-to-many relationship.

***Note:** it is possible that this same situation will be repeated in the project update #28 .*

---

Closes #35 