### PR TITLE
Implement PATCH endpoint to update project

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -743,6 +743,56 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Modifies the details of a specific project by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Updates a project",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated project data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ProjectUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ProjectResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{id}/environments": {
@@ -1313,6 +1363,14 @@ const docTemplate = `{
                     ]
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ProjectUpdate": {
+            "type": "object",
+            "properties": {
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -735,6 +735,56 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Modifies the details of a specific project by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Updates a project",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated project data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ProjectUpdate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ProjectResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Default error response for all failures",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{id}/environments": {
@@ -1305,6 +1355,14 @@
                     ]
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ProjectUpdate": {
+            "type": "object",
+            "properties": {
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -228,6 +228,11 @@ definitions:
       version:
         type: string
     type: object
+  dto.ProjectUpdate:
+    properties:
+      name:
+        type: string
+    type: object
   dto.ServiceCreate:
     properties:
       name:
@@ -722,6 +727,38 @@ paths:
       security:
       - OAuth2Password: []
       summary: Retrieves a project by ID
+      tags:
+      - Projects
+    patch:
+      consumes:
+      - application/json
+      description: Modifies the details of a specific project by ID
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Updated project data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ProjectUpdate'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ProjectResponse'
+        default:
+          description: Default error response for all failures
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+      security:
+      - OAuth2Password: []
+      summary: Updates a project
       tags:
       - Projects
   /api/v1/projects/{id}/environments:

--- a/internal/adapters/http/handlers/project.go
+++ b/internal/adapters/http/handlers/project.go
@@ -84,6 +84,53 @@ func GetProject(projectService inbound.ProjectHTTPPort) gin.HandlerFunc {
 	}
 }
 
+// UpdateProject godoc
+// @Summary Updates a project
+// @Description Modifies the details of a specific project by ID
+// @Tags Projects
+// @Security OAuth2Password
+// @Accept json
+// @Produce json
+// @Param id path int true "Project ID"
+// @Param request body dto.ProjectUpdate true "Updated project data"
+// @Success 200 {object} dto.ProjectResponse
+// @Failure default {object} utils.ErrorResponse "Default error response for all failures"
+// @Router /api/v1/projects/{id} [patch]
+func UpdateProject(projectService inbound.ProjectHTTPPort) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		projectID, paramErr := strconv.Atoi(c.Param("id"))
+		if paramErr != nil {
+			c.AbortWithStatusJSON(
+				http.StatusBadRequest,
+				gin.H{"error": "Invalid Project ID"},
+			)
+			return
+		}
+
+		var req dto.ProjectUpdate
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(
+				utils.GetBindJSONErrorStatusCode(err),
+				gin.H{"error": err.Error()},
+			)
+			return
+		}
+
+		project, err := projectService.Update(
+			c.Request.Context(), projectID, &req,
+		)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				utils.GetDomainErrorStatusCode(err),
+				gin.H{"error": err.Error()},
+			)
+			return
+		}
+
+		c.JSON(http.StatusOK, project)
+	}
+}
+
 // GetEnvironmentsByProject godoc
 // @Summary Retrieves all environments for a specific project
 // @Description Fetches a list of environments associated with a given project

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -90,6 +90,7 @@ func (s *Server) setupRoutes(router *gin.RouterGroup) {
 		{
 			projects.POST("", handlers.CreateProject(s.projectService))
 			projects.GET("/:id", handlers.GetProject(s.projectService))
+			projects.PATCH("/:id", handlers.UpdateProject(s.projectService))
 			projects.GET(
 				"/:id/environments",
 				handlers.GetEnvironmentsByProject(s.projectService),

--- a/internal/adapters/persistence/repository/project.go
+++ b/internal/adapters/persistence/repository/project.go
@@ -63,9 +63,9 @@ func (r *ProjectRepository) UpdateStatus(
 
 func (r *ProjectRepository) Update(
 	ctx context.Context, id int, update *dto.ProjectUpdate,
-) *errors.Error {
+) (*entities.Project, *errors.Error) {
 	if update == nil {
-		return nil
+		return r.FindByID(ctx, id)
 	}
 
 	var updates []string
@@ -79,7 +79,7 @@ func (r *ProjectRepository) Update(
 	}
 
 	if len(updates) == 0 {
-		return nil
+		return r.FindByID(ctx, id)
 	}
 
 	query := fmt.Sprintf(
@@ -93,14 +93,14 @@ func (r *ProjectRepository) Update(
 
 	result, err := r.pool.Exec(ctx, query, args...)
 	if err != nil {
-		return r.handlerErr(err)
+		return nil, r.handlerErr(err)
 	}
 
 	if result.RowsAffected() == 0 {
-		return errors.ErrProjectNotFound
+		return nil, errors.ErrProjectNotFound
 	}
 
-	return nil
+	return r.FindByID(ctx, id)
 }
 
 func (r *ProjectRepository) Exists(

--- a/internal/app/project.go
+++ b/internal/app/project.go
@@ -14,6 +14,39 @@ type ProjectUseCase struct {
 	environmentRepo outbound.EnvironmentPort
 }
 
+func (u *ProjectUseCase) Update(
+	ctx context.Context, id int, req *dto.ProjectUpdate,
+) (*dto.ProjectResponse, *errors.Error) {
+	project, err := u.projectRepo.Update(ctx, id, req)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResp := make(
+		[]*dto.ProjectServiceResponse, len(project.Services),
+	)
+	for i, service := range project.Services {
+		serviceResp[i] = &dto.ProjectServiceResponse{
+			ID:             service.ID,
+			Name:           service.Name,
+			Version:        service.Version,
+			NextReset:      service.NextReset,
+			MaxRequest:     service.MaxRequest,
+			ResetFrequency: service.ResetFrequency,
+			AssignedAt:     service.AssignedAt,
+		}
+	}
+
+	return &dto.ProjectResponse{
+		ID:        project.ID,
+		Name:      project.Name,
+		Status:    project.Status,
+		ClientID:  project.ClientID,
+		CreatedAt: project.CreatedAt,
+		Services:  serviceResp,
+	}, nil
+}
+
 func (u *ProjectUseCase) AssignService(
 	ctx context.Context, id int, req *dto.ProjectService,
 ) *errors.Error {

--- a/internal/ports/inbound/project.go
+++ b/internal/ports/inbound/project.go
@@ -9,6 +9,7 @@ import (
 
 type ProjectHTTPPort interface {
 	Create(ctx context.Context, req *dto.ProjectCreate) (*dto.ProjectResponse, *errors.Error)
+	Update(ctx context.Context, id int, req *dto.ProjectUpdate) (*dto.ProjectResponse, *errors.Error)
 	GetByID(ctx context.Context, id int) (*dto.ProjectResponse, *errors.Error)
 	AssignService(ctx context.Context, id int, req *dto.ProjectService) *errors.Error
 	RemoveService(ctx context.Context, id, serviceID int) *errors.Error

--- a/internal/ports/outbound/project.go
+++ b/internal/ports/outbound/project.go
@@ -11,6 +11,7 @@ import (
 type ProjectPort interface {
 	Save(ctx context.Context, project *entities.Project) *errors.Error
 	Exists(ctx context.Context, id int) (bool, *errors.Error)
+	Update(ctx context.Context, id int, update *dto.ProjectUpdate) (*entities.Project, *errors.Error)
 	FindByID(ctx context.Context, id int) (*entities.Project, *errors.Error)
 	AddService(ctx context.Context, id int, service *entities.ProjectService) *errors.Error
 	FindByClient(ctx context.Context, clientID int) ([]*entities.Project, *errors.Error)


### PR DESCRIPTION
This PR introduces support for partial updates to project entities through a new PATCH `/api/v1/projects/{id}` endpoint. The update logic currently supports the name field and is designed to allow easy future extension for additional updatable fields.

## What was done:

1. **Repository layer updated:** Update logic was implemented similarly to PR #55, as the same issue arose when attempting to retrieve the updated entity.

2. **Use case logic implemented:** Added the necessary logic and mappings in the use case to support partial updates and return the appropriate DTOs.

3. **Endpoint and Swagger documentation:** The PATCH `/api/v1/projects/{id}` endpoint was implemented with full Swagger documentation for request/response structure and status codes.

## Behavior:

* Only updates the name field if it's present and non-empty.
* Returns 404 Not Found if the project does not exist.
* Returns the updated project in the response body with status 200 OK.

---

Closes #28 