### PR TITLE
Normalize all timestamp handling to UTC to fix timezone offset issues

### DIFF
--- a/internal/adapters/security/jwt.go
+++ b/internal/adapters/security/jwt.go
@@ -17,7 +17,7 @@ type JWTProvider struct {
 func (p *JWTProvider) GenerateToken(
 	ctx context.Context, subject string,
 ) (*dto.TokenResponse, *errors.Error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	expTime := now.Add(time.Hour)
 
 	claims := jwt.MapClaims{

--- a/internal/app/api_key.go
+++ b/internal/app/api_key.go
@@ -322,7 +322,7 @@ func (u *APIKeyUseCase) validateAndReserve(
 			ServiceID:     service.ID,
 			EnvironmentID: apiKey.EnvironmentID,
 			RequestTime:   req.RequestTime,
-			ExpiresAt:     time.Now().Add(12 * time.Hour),
+			ExpiresAt:     time.Now().UTC().Add(12 * time.Hour),
 		}, nil
 }
 
@@ -506,7 +506,7 @@ func (u *APIKeyUseCase) GetAPIKeysByEnvironment(
 func (u *APIKeyUseCase) Update(
 	ctx context.Context, id int, req *dto.APIKeyUpdate,
 ) (*dto.APIKeyResponse, *errors.Error) {
-	if !req.ExpiresAt.IsZero() && req.ExpiresAt.Before(time.Now()) {
+	if !req.ExpiresAt.IsZero() && req.ExpiresAt.Before(time.Now().UTC()) {
 		return nil, errors.ErrAPIKeyInvalidExpiresAt
 	}
 

--- a/internal/domain/dto/api_key.go
+++ b/internal/domain/dto/api_key.go
@@ -10,7 +10,7 @@ type APIKeyValidate struct {
 	Key            string    `json:"key"`
 	Service        string    `json:"service"`
 	Environment    string    `json:"environment"`
-	RequestTime    time.Time `json:"request_time"`
+	RequestTime    time.Time `json:"request_time" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 	ServiceVersion string    `json:"service_version"`
 }
 
@@ -55,7 +55,7 @@ type APIKeyValidateReservationResponse struct {
 	Code      enums.ReserveExecutionStatusCode `json:"code,omitempty"`
 }
 type APIKeyCreate struct {
-	ExpiresAt     time.Time `json:"expires_at"`
+	ExpiresAt     time.Time `json:"expires_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 	EnvironmentID int       `json:"environment_id" binding:"required"`
 }
 
@@ -63,12 +63,12 @@ type APIKeyResponse struct {
 	ID            int                `json:"id"`
 	Key           string             `json:"key"`
 	Status        enums.APIKeyStatus `json:"status" enums:"active,deactivated" swaggertype:"string"`
-	LastUsed      time.Time          `json:"last_used"`
-	ExpiresAt     time.Time          `json:"expires_at"`
+	LastUsed      time.Time          `json:"last_used" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
+	ExpiresAt     time.Time          `json:"expires_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 	EnvironmentID int                `json:"environment_id"`
-	CreatedAt     time.Time          `json:"created_at"`
+	CreatedAt     time.Time          `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type APIKeyUpdate struct {
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }

--- a/internal/domain/dto/auth.go
+++ b/internal/domain/dto/auth.go
@@ -10,7 +10,7 @@ type Authenticate struct {
 type TokenResponse struct {
 	Token     string    `json:"access_token"`
 	TokenType string    `json:"token_type"`
-	ExpiresIn time.Time `json:"expires_in"`
+	ExpiresIn time.Time `json:"expires_in" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type AuthenticateResponse struct {

--- a/internal/domain/dto/client.go
+++ b/internal/domain/dto/client.go
@@ -21,7 +21,7 @@ type ClientResponse struct {
 	Type      enums.ClientType `json:"type" enums:"developer,organization" swaggertype:"string"`
 	Name      string           `json:"name"`
 	Email     string           `json:"email"`
-	CreatedAt time.Time        `json:"created_at"`
+	CreatedAt time.Time        `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type ClientUpdate struct {

--- a/internal/domain/dto/environment.go
+++ b/internal/domain/dto/environment.go
@@ -34,7 +34,7 @@ type EnvironmentServiceResponse struct {
 	Version          string    `json:"version"`
 	MaxRequest       int       `json:"max_request"`
 	AvailableRequest int       `json:"available_request"`
-	AssignedAt       time.Time `json:"assigned_at"`
+	AssignedAt       time.Time `json:"assigned_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type EnvironmentResponse struct {
@@ -42,7 +42,7 @@ type EnvironmentResponse struct {
 	Name      string                  `json:"name"`
 	Status    enums.EnvironmentStatus `json:"status" enums:"active,deactivated" swaggertype:"string"`
 	ProjectID int                     `json:"project_id"`
-	CreatedAt time.Time               `json:"created_at"`
+	CreatedAt time.Time               `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 
 	Services []*EnvironmentServiceResponse `json:"services"`
 }

--- a/internal/domain/dto/project.go
+++ b/internal/domain/dto/project.go
@@ -24,10 +24,10 @@ type ProjectServiceResponse struct {
 	ID             int                                `json:"id"`
 	Name           string                             `json:"name"`
 	Version        string                             `json:"version"`
-	NextReset      time.Time                          `json:"next_reset"`
+	NextReset      time.Time                          `json:"next_reset" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 	MaxRequest     int                                `json:"max_request"`
 	ResetFrequency enums.ProjectServiceResetFrequency `json:"reset_frequency" enums:"daily,weekly,biweekly,monthly," swaggertype:"string"`
-	AssignedAt     time.Time                          `json:"assigned_at"`
+	AssignedAt     time.Time                          `json:"assigned_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type ProjectResponse struct {
@@ -35,7 +35,7 @@ type ProjectResponse struct {
 	Name      string              `json:"name"`
 	Status    enums.ProjectStatus `json:"status" enums:"in_production,in_development,deactivated" swaggertype:"string"`
 	ClientID  int                 `json:"client_id"`
-	CreatedAt time.Time           `json:"created_at"`
+	CreatedAt time.Time           `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 
 	Services []*ProjectServiceResponse `json:"services"`
 }

--- a/internal/domain/dto/request_log.go
+++ b/internal/domain/dto/request_log.go
@@ -16,8 +16,8 @@ type RequestLogResponse struct {
 	ID              int                             `json:"id"`
 	APIKey          string                          `json:"api_key"`
 	ServiceID       int                             `json:"service_id"`
-	RequestTime     time.Time                       `json:"request_time"`
+	RequestTime     time.Time                       `json:"request_time" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 	EnvironmentID   int                             `json:"environment_id"`
 	ExecutionStatus enums.RequestLogExecutionStatus `json:"execution_status" enums:"success,failed,pending,unauthorized,server error" swaggertype:"string"`
-	CreatedAt       time.Time                       `json:"created_at"`
+	CreatedAt       time.Time                       `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }

--- a/internal/domain/dto/service.go
+++ b/internal/domain/dto/service.go
@@ -20,7 +20,7 @@ type ServiceResponse struct {
 	Name      string              `json:"name"`
 	Status    enums.ServiceStatus `json:"status" enums:"active,deactivated,deprecated" swaggertype:"string"`
 	Version   string              `json:"version"`
-	CreatedAt time.Time           `json:"created_at"`
+	CreatedAt time.Time           `json:"created_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`
 }
 
 type ServiceStatusUpdate struct {

--- a/internal/domain/entities/api_key.go
+++ b/internal/domain/entities/api_key.go
@@ -33,7 +33,7 @@ func (a *APIKey) GenerateKey() *errors.Error {
 }
 
 func (a *APIKey) IsExpired() bool {
-	return !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now())
+	return !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now().UTC())
 }
 
 func (a *APIKey) IsActive() bool {

--- a/internal/domain/entities/project.go
+++ b/internal/domain/entities/project.go
@@ -37,7 +37,7 @@ func (p *ProjectService) Validate() *errors.Error {
 }
 
 func (p *ProjectService) CalculateNextReset() {
-	now := time.Now()
+	now := time.Now().UTC()
 	startOfDay := time.Date(
 		now.Year(),
 		now.Month(),


### PR DESCRIPTION
This PR addresses a timezone-related issue affecting multiple entities that store date/time values from HTTP and gRPC layers.

## Changes included:

* All incoming timestamps are now normalized to UTC, ensuring the exact value received (e.g., 2025-04-10T15:00:00Z) is preserved without unintended offset conversion.
* All `time.Now()` calls throughout the codebase have been updated to use `.UTC()` to ensure consistent behavior and avoid implicit local time usage.

These changes ensure that all date/time values are handled in UTC consistently across the system, preventing incorrect storage or interpretation due to local timezone offsets.

## Affected entities:

* `api_key.expires_at`
* `project_service.next_reset`
* `request_log.request_time`
* `reservation.expires_at`

The responsibility for providing correctly formatted and timezone-aware timestamps now lies with the API clients.

---

Closes #52 