### PR TITLE
Set global time zone to UTC and remove redundant UTC conversions

### DIFF
--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/MAD-py/pandora-core/internal/adapters/grpc"
 	"github.com/MAD-py/pandora-core/internal/adapters/persistence"
@@ -11,6 +12,8 @@ import (
 )
 
 func main() {
+	time.Local = time.UTC
+
 	log.Println("[INFO] Starting Pandora Core (gRPC)...")
 	db, err := persistence.NewPersistence("postgresql://postgres:postgres@localhost:5436/pandora")
 	if err != nil {

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/MAD-py/pandora-core/cmd/http/config"
 	"github.com/MAD-py/pandora-core/internal/adapters/http"
@@ -13,6 +14,8 @@ import (
 )
 
 func main() {
+	time.Local = time.UTC
+
 	log.Println("[INFO] Starting Pandora Core (API RESTful)...")
 
 	cfg, err := config.LoadConfig()

--- a/internal/adapters/security/jwt.go
+++ b/internal/adapters/security/jwt.go
@@ -17,7 +17,7 @@ type JWTProvider struct {
 func (p *JWTProvider) GenerateToken(
 	ctx context.Context, subject string,
 ) (*dto.TokenResponse, *errors.Error) {
-	now := time.Now().UTC()
+	now := time.Now()
 	expTime := now.Add(time.Hour)
 
 	claims := jwt.MapClaims{

--- a/internal/app/api_key.go
+++ b/internal/app/api_key.go
@@ -322,7 +322,7 @@ func (u *APIKeyUseCase) validateAndReserve(
 			ServiceID:     service.ID,
 			EnvironmentID: apiKey.EnvironmentID,
 			RequestTime:   req.RequestTime,
-			ExpiresAt:     time.Now().UTC().Add(12 * time.Hour),
+			ExpiresAt:     time.Now().Add(12 * time.Hour),
 		}, nil
 }
 
@@ -506,7 +506,7 @@ func (u *APIKeyUseCase) GetAPIKeysByEnvironment(
 func (u *APIKeyUseCase) Update(
 	ctx context.Context, id int, req *dto.APIKeyUpdate,
 ) (*dto.APIKeyResponse, *errors.Error) {
-	if !req.ExpiresAt.IsZero() && req.ExpiresAt.Before(time.Now().UTC()) {
+	if !req.ExpiresAt.IsZero() && req.ExpiresAt.Before(time.Now()) {
 		return nil, errors.ErrAPIKeyInvalidExpiresAt
 	}
 

--- a/internal/domain/entities/api_key.go
+++ b/internal/domain/entities/api_key.go
@@ -33,7 +33,7 @@ func (a *APIKey) GenerateKey() *errors.Error {
 }
 
 func (a *APIKey) IsExpired() bool {
-	return !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now().UTC())
+	return !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now())
 }
 
 func (a *APIKey) IsActive() bool {

--- a/internal/domain/entities/project.go
+++ b/internal/domain/entities/project.go
@@ -37,7 +37,7 @@ func (p *ProjectService) Validate() *errors.Error {
 }
 
 func (p *ProjectService) CalculateNextReset() {
-	now := time.Now().UTC()
+	now := time.Now()
 	startOfDay := time.Date(
 		now.Year(),
 		now.Month(),


### PR DESCRIPTION
This PR sets the global default time zone to UTC using the standard library configuration. As a result, all usages of `time.Now()` now return UTC time by default, removing the need for explicit `.UTC()` calls across the codebase. These redundant calls have been removed for clarity and consistency.

## Why this matters
This change directly addresses a long-standing issue with handling nullable timestamp fields from PostgreSQL using the `COALESCE` fallback pattern:

```sql
COALESCE(expires_at, '0001-01-01 00:00:00.0+00')
```

### Problem:

The string '0001-01-01 00:00:00.0+00' is not parsed consistently by PostgreSQL, which may return a value such as:

```makefile
0000-12-31T19:03:44-04:56
```

This causes `time.IsZero()` in Go to fail, as the value is no longer the zero time. The issue stems from quirks in historical date handling and timezone conversion in PostgreSQL.

### Fix:

By enforcing UTC globally, we ensure consistent parsing and reduce the chance of incorrect behavior due to implicit timezone shifts. This approach avoids relying on connection-level time zone settings that may vary across environments.

## Improvements over #61

While PR #61 proposed a workaround, this PR offers a more robust and centralized solution by:

* Setting the default time zone globally
* Removing all scattered and potentially inconsistent .UTC() usages
* Preventing similar issues in future time handling

---

Closes #53 