### PR TITLE
Improve error message when assigning an already-linked service to a project #45

### DIFF
--- a/internal/app/project.go
+++ b/internal/app/project.go
@@ -62,6 +62,9 @@ func (u *ProjectUseCase) AssignService(
 
 	service.CalculateNextReset()
 	if err := u.projectRepo.AddService(ctx, id, service); err != nil {
+		if err == errors.ErrUniqueViolation {
+			return nil, errors.ErrProjectServiceAlreadyExists
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR improves the clarity of error messages when attempting to assign a service that is already associated with a given project via: POST `/api/v1/projects/{id}/services`

## What was done:

* Identified and intercepted the specific case of a unique key violation returned by the database during the `AddService` call in the `ProjectRepository`.
* Mapped the raw error (`ErrUniqueViolation`) to a more descriptive domain-specific error: `ErrProjectServiceAlreadyExists`

This change ensures that clients now receive a meaningful and user-friendly error message such as:

```markdown
"Service is already configured for this Project"
```

instead of a generic `VALIDATION_ERROR: Unique key violation`.

## Why it matters:

* The existing error message did not reflect the true cause of the issue, making it harder to debug and handle gracefully on the client side.
* The new error improves the developer experience and aligns with the behavior described in the original issue.

No other error mappings were affected, as existing cases for missing projects or services are already correctly handled and remain unchanged.

---

Closes #45 