### PR TITLE
Adjusted the ValidateAndReserve grpc service to use the common methods for validations

### DIFF
--- a/internal/domain/dto/api_key.go
+++ b/internal/domain/dto/api_key.go
@@ -24,11 +24,12 @@ type APIKeyValidateBooking struct {
 }
 
 type APIKeyValidateResponse struct {
-	RequestID        string                           `json:"request_id,omitempty"`
-	AvailableRequest int                              `json:"available_request,omitempty"`
-	Valid            bool                             `json:"valid"`
-	Message          string                           `json:"message,omitempty"`
-	Code             enums.ReserveExecutionStatusCode `json:"code,omitempty"`
+	RequestID        string                   `json:"request_id,omitempty"`
+	ReservationID    string                   `json:"reservation_id,omitempty"` // Only for reservations
+	AvailableRequest int                      `json:"available_request,omitempty"`
+	Valid            bool                     `json:"valid"`
+	Message          string                   `json:"message,omitempty"`
+	Code             enums.ValidateStatusCode `json:"code,omitempty"`
 }
 
 type APIKeyValidateConsumeResponse struct {
@@ -43,20 +44,11 @@ type APIKeyValidateBookingResponse struct {
 	BookingID string `json:"booking_id"`
 }
 
-type APIKeyValidateReserveResponse struct {
-	RequestID        string                           `json:"request_id,omitempty"`
-	ReservationID    string                           `json:"reservation_id,omitempty"`
-	AvailableRequest int                              `json:"available_request,omitempty"`
-	Valid            bool                             `json:"valid"`
-	Message          string                           `json:"message,omitempty"`
-	Code             enums.ReserveExecutionStatusCode `json:"code,omitempty"`
-}
-
 type APIKeyValidateReservationResponse struct {
-	RequestID string                           `json:"request_id,omitempty"`
-	Valid     bool                             `json:"valid"`
-	Message   string                           `json:"message,omitempty"`
-	Code      enums.ReserveExecutionStatusCode `json:"code,omitempty"`
+	RequestID string                   `json:"request_id,omitempty"`
+	Valid     bool                     `json:"valid"`
+	Message   string                   `json:"message,omitempty"`
+	Code      enums.ValidateStatusCode `json:"code,omitempty"`
 }
 type APIKeyCreate struct {
 	ExpiresAt     time.Time `json:"expires_at" time_format:"2006-01-02T15:04:05Z07:00" time_utc:"1"`

--- a/internal/domain/enums/reserve.go
+++ b/internal/domain/enums/reserve.go
@@ -5,21 +5,18 @@ import (
 	"fmt"
 )
 
-type ReserveExecutionStatusCode int
+type ValidateStatusCode int
 
 const (
-	ReserveExecutionStatusNull ReserveExecutionStatusCode = iota
-	ReserveExecutionStatusKeyNotFound
-	ReserveExecutionStatusInvalidKey
-	ReserveExecutionStatusDeactivatedKey
-	ReserveExecutionStatusExpiredKey
-	ReserveExecutionStatusServiceNotFound
-	ReserveExecutionStatusDeactivatedService
-	ReserveExecutionStatusDeprecatedService
-	ReserveExecutionStatusEnvironmentNotFound
-	ReserveExecutionStatusDeactivatedEnvironment
-	ReserveExecutionStatusExceededRequests
-	ReserveExecutionStatusActiveReservations
+	ValidateStatusNull ValidateStatusCode = iota
+	ValidateStatusDeactivatedKey
+	ValidateStatusExpiredKey
+	ValidateStatusServiceNotFound
+	ValidateStatusDeactivatedEnvironment
+	ValidateStatusExceededRequests
+	ValidateStatusActiveReservations
+	ValidateStatusInvalidEnvironmentKey
+	ValidateStatusEnvironmentServiceInvalid
 
 	ReservationExecutionStatusNotFound
 	ReservationExecutionStatusInvalidService
@@ -28,33 +25,27 @@ const (
 	ReservationExecutionStatusInvalidEnvironment
 	ReservationExecutionStatusEnvironmentNotActive
 
-	ValidateStatusInvalidEnvironmentKey
-	ValidateStatusEnvironmentServiceInvalid
+	ValidateStatusKeyNotFound
+	ValidateStatusInvalidKey
 )
 
-func (es ReserveExecutionStatusCode) String() string {
+func (es ValidateStatusCode) String() string {
 	switch es {
-	case ReserveExecutionStatusKeyNotFound:
+	case ValidateStatusKeyNotFound:
 		return "KEY_NOT_FOUND"
-	case ReserveExecutionStatusInvalidKey:
+	case ValidateStatusInvalidKey:
 		return "INVALID_KEY"
-	case ReserveExecutionStatusDeactivatedKey:
+	case ValidateStatusDeactivatedKey:
 		return "DEACTIVATED_KEY"
-	case ReserveExecutionStatusExpiredKey:
+	case ValidateStatusExpiredKey:
 		return "EXPIRED_KEY"
-	case ReserveExecutionStatusServiceNotFound:
+	case ValidateStatusServiceNotFound:
 		return "SERVICE_NOT_FOUND"
-	case ReserveExecutionStatusDeactivatedService:
-		return "DEACTIVATED_SERVICE"
-	case ReserveExecutionStatusDeprecatedService:
-		return "DEPRECATED_SERVICE"
-	case ReserveExecutionStatusEnvironmentNotFound:
-		return "ENVIRONMENT_NOT_FOUND"
-	case ReserveExecutionStatusDeactivatedEnvironment:
+	case ValidateStatusDeactivatedEnvironment:
 		return "DEACTIVATED_ENVIRONMENT"
-	case ReserveExecutionStatusExceededRequests:
+	case ValidateStatusExceededRequests:
 		return "EXCEEDED_AVAILABLE_REQUEST"
-	case ReserveExecutionStatusActiveReservations:
+	case ValidateStatusActiveReservations:
 		return "ACTIVE_RESERVATIONS"
 	case ReservationExecutionStatusNotFound:
 		return "RESERVATION_NOT_FOUND"
@@ -73,17 +64,17 @@ func (es ReserveExecutionStatusCode) String() string {
 	case ValidateStatusEnvironmentServiceInvalid:
 		return "ENVIRONMENT_SERVICE_INVALID"
 	default:
-		panic("unknown ReserveExecutionStatusCode")
+		panic("unknown ValidateStatusCode")
 	}
 }
 
-func (s *ReserveExecutionStatusCode) Scan(v any) error {
+func (s *ValidateStatusCode) Scan(v any) error {
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("invalid reserve execution status code: %v", v)
 	}
 
-	status, err := ParseReserveExecutionStatusCode(str)
+	status, err := ParseValidateStatusCode(str)
 	if err != nil {
 		return err
 	}
@@ -92,13 +83,13 @@ func (s *ReserveExecutionStatusCode) Scan(v any) error {
 	return nil
 }
 
-func (es *ReserveExecutionStatusCode) UnmarshalJSON(b []byte) error {
+func (es *ValidateStatusCode) UnmarshalJSON(b []byte) error {
 	var ss string
 	if err := json.Unmarshal(b, &ss); err != nil {
 		return err
 	}
 
-	parsed, err := ParseReserveExecutionStatusCode(ss)
+	parsed, err := ParseValidateStatusCode(ss)
 	if err != nil {
 		return err
 	}
@@ -107,34 +98,28 @@ func (es *ReserveExecutionStatusCode) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (es *ReserveExecutionStatusCode) MarshalJSON() ([]byte, error) {
+func (es *ValidateStatusCode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(es.String())
 }
 
-func ParseReserveExecutionStatusCode(es string) (ReserveExecutionStatusCode, error) {
+func ParseValidateStatusCode(es string) (ValidateStatusCode, error) {
 	switch es {
 	case "KEY_NOT_FOUND":
-		return ReserveExecutionStatusKeyNotFound, nil
+		return ValidateStatusKeyNotFound, nil
 	case "INVALID_KEY":
-		return ReserveExecutionStatusInvalidKey, nil
+		return ValidateStatusInvalidKey, nil
 	case "DEACTIVATED_KEY":
-		return ReserveExecutionStatusDeactivatedKey, nil
+		return ValidateStatusDeactivatedKey, nil
 	case "EXPIRED_KEY":
-		return ReserveExecutionStatusExpiredKey, nil
+		return ValidateStatusExpiredKey, nil
 	case "SERVICE_NOT_FOUND":
-		return ReserveExecutionStatusServiceNotFound, nil
-	case "DEACTIVATED_SERVICE":
-		return ReserveExecutionStatusDeactivatedService, nil
-	case "DEPRECATED_SERVICE":
-		return ReserveExecutionStatusDeprecatedService, nil
-	case "ENVIRONMENT_NOT_FOUND":
-		return ReserveExecutionStatusEnvironmentNotFound, nil
+		return ValidateStatusServiceNotFound, nil
 	case "DEACTIVATED_ENVIRONMENT":
-		return ReserveExecutionStatusDeactivatedEnvironment, nil
+		return ValidateStatusDeactivatedEnvironment, nil
 	case "EXCEEDED_AVAILABLE_REQUEST":
-		return ReserveExecutionStatusExceededRequests, nil
+		return ValidateStatusExceededRequests, nil
 	case "ACTIVE_RESERVATIONS":
-		return ReserveExecutionStatusActiveReservations, nil
+		return ValidateStatusActiveReservations, nil
 	case "RESERVATION_NOT_FOUND":
 		return ReservationExecutionStatusNotFound, nil
 	case "INVALID_SERVICE":

--- a/internal/ports/inbound/api_key.go
+++ b/internal/ports/inbound/api_key.go
@@ -15,6 +15,6 @@ type APIKeyHTTPPort interface {
 
 type APIKeyGRPCPort interface {
 	ValidateAndConsume(ctx context.Context, req *dto.APIKeyValidate) (*dto.APIKeyValidateResponse, *errors.Error)
-	ValidateAndReserve(ctx context.Context, req *dto.APIKeyValidate) (*dto.APIKeyValidateReserveResponse, *errors.Error)
+	ValidateAndReserve(ctx context.Context, req *dto.APIKeyValidate) (*dto.APIKeyValidateResponse, *errors.Error)
 	ValidateWithReservation(ctx context.Context, req *dto.APIKeyValidateReserve) (*dto.APIKeyValidateReservationResponse, *errors.Error)
 }


### PR DESCRIPTION
Related issue: #70 

- Updated validateAndReserve for use common methods for validations on api_key, environment, service and handler error.
- Improvement enum options about validations
- Unified struct to response in grpc services ValidateAndReserve and ValidateAndConsume
- Test for ValidateAndReserve,  ValidateAndConsume and ValidateWithReservation using grpc python client for testing both operation flows and error cases.

![Captura desde 2025-04-24 11-35-30](https://github.com/user-attachments/assets/b935acbe-2cc0-4f00-91e9-5e94328fb65f)

![Captura desde 2025-04-24 11-41-29](https://github.com/user-attachments/assets/e81cbd77-5c98-4391-8b7c-16cc33793266)

This process in the ValidateAndReserve grpc service includes the correct validation of the environment and the services belonging to the environment.

Closes #70 