### PR TITLE
Implement unified entry point to run HTTP and gRPC servers concurrently

### DIFF
--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -18,12 +18,15 @@ func main() {
 	log.Println("[INFO] Starting Pandora Core (gRPC)...")
 
 	cfg := config.LoadGRPCConfig()
+	log.Printf("[INFO] gRPC config loaded")
 
 	validator := validator.NewValidator()
+	log.Println("[INFO] Validator initialized")
 
 	repositories := persistence.NewRepositories(
 		persistence.PostgresDriver, cfg.DBDNS(),
 	)
+	log.Println("[INFO] Repositories initialized successfully")
 
 	gRPCDeps := bootstrap.NewDependencies(validator, repositories)
 

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -19,32 +19,21 @@ func main() {
 	log.Println("[INFO] Starting Pandora Core (API RESTful)...")
 
 	cfg := config.LoadHTTPConfig()
-	// if err != nil {
-	// 	log.Fatalf("[ERROR] Error loading configuration: %v", err)
-	// }
-
-	log.Println("[INFO] Configuration loaded successfully from environment variables and configuration files.")
+	log.Printf("[INFO] HTTP config loaded")
 
 	validator := validator.NewValidator()
+	log.Println("[INFO] Validator initialized")
 
 	repositories := persistence.NewRepositories(
 		persistence.PostgresDriver, cfg.DBDNS(),
 	)
-	// if err != nil {
-	// 	log.Fatalf("[ERROR] Failed to initialize persistence: %v", err)
-	// }
+	log.Println("[INFO] Repositories initialized successfully")
 
 	jwtProvider := security.NewJWTProvider([]byte(cfg.JWTSecret()))
+	log.Println("[INFO] JWT provider initialized")
 
-	credentialsFile := cfg.CredentialsFile()
-	// if err != nil {
-	// 	log.Fatalf("[ERROR] Failed to load credentials file: %v", err)
-	// }
-
-	credentialsRepo := security.NewCredentialsRepository(credentialsFile)
-	// if err != nil {
-	// 	log.Fatalf("[ERROR] Failed to initialize credentials repository: %v", err)
-	// }
+	credentialsRepo := security.NewCredentialsRepository(cfg.CredentialsFile())
+	log.Println("[INFO] Credentials repository initialized")
 
 	httpDeps := bootstrap.NewDependencies(
 		validator,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,73 @@
 package main
 
-func main() {
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
 
+	"golang.org/x/sync/errgroup"
+
+	"github.com/MAD-py/pandora-core/internal/adapters/grpc"
+	grpcBootstrap "github.com/MAD-py/pandora-core/internal/adapters/grpc/bootstrap"
+	"github.com/MAD-py/pandora-core/internal/adapters/http"
+	httpBootstrap "github.com/MAD-py/pandora-core/internal/adapters/http/bootstrap"
+	"github.com/MAD-py/pandora-core/internal/adapters/persistence"
+	"github.com/MAD-py/pandora-core/internal/adapters/security"
+	"github.com/MAD-py/pandora-core/internal/config"
+	"github.com/MAD-py/pandora-core/internal/validator"
+)
+
+func main() {
+	time.Local = time.UTC
+
+	log.Println("[INFO] Starting Pandora Core (API RESTful + gRPC)...")
+
+	cfg := config.LoadConfig()
+
+	log.Printf("[INFO] HTTP and gRPC config loaded")
+
+	validator := validator.NewValidator()
+	log.Println("[INFO] Validator initialized")
+
+	repositories := persistence.NewRepositories(
+		persistence.PostgresDriver, cfg.DBDNS(),
+	)
+	log.Println("[INFO] Repositories initialized successfully")
+
+	jwtProvider := security.NewJWTProvider([]byte(cfg.HTTPConfig().JWTSecret()))
+	log.Println("[INFO] JWT provider initialized")
+
+	credentialsRepo := security.NewCredentialsRepository(cfg.HTTPConfig().CredentialsFile())
+	log.Println("[INFO] Credentials repository initialized")
+
+	gRPCDeps := grpcBootstrap.NewDependencies(validator, repositories)
+
+	grpcSrv := grpc.NewServer(
+		fmt.Sprintf(":%s", cfg.GRPCConfig().Port()),
+		gRPCDeps,
+	)
+
+	httpDeps := httpBootstrap.NewDependencies(
+		validator,
+		repositories,
+		jwtProvider,
+		credentialsRepo,
+	)
+
+	httpSrv := http.NewServer(
+		fmt.Sprintf(":%s", cfg.HTTPConfig().Port()),
+		cfg.HTTPConfig().ExposeVersion(),
+		httpDeps,
+	)
+
+	var g errgroup.Group
+
+	g.Go(httpSrv.Run)
+	g.Go(grpcSrv.Run)
+
+	if err := g.Wait(); err != nil {
+		log.Fatalf("[FATAL] One of the servers failed: %v", err)
+		os.Exit(1)
+	}
 }

--- a/internal/adapters/grpc/server.go
+++ b/internal/adapters/grpc/server.go
@@ -33,7 +33,7 @@ func (s *Server) setupServices() {
 	reservation.RegisterService(s.server, s.deps)
 }
 
-func (s *Server) Run() {
+func (s *Server) Run() error {
 	validator, err := protovalidator.New()
 	if err != nil {
 		panic("failed to create protovalidate validator")
@@ -57,14 +57,17 @@ func (s *Server) Run() {
 
 	listener, err := net.Listen("tcp", s.addr)
 	if err != nil {
-		log.Fatalf("[ERROR] Failed to listen: %v", err)
+		log.Printf("[ERROR] Failed to listen: %v\n", err)
+		return err
 	}
 
 	log.Printf("[INFO] gRPC server is running on port: %s\n", s.addr)
 	log.Printf("[INFO] Pandora Core is fully initialized and ready to accept requests.\n\n")
 	if err := s.server.Serve(listener); err != nil {
-		log.Fatalf("[ERROR] Failed to serve: %v", err)
+		log.Printf("[ERROR] Failed to serve: %v\n", err)
+		return err
 	}
+	return nil
 }
 
 func NewServer(addr string, deps *bootstrap.Dependencies) *Server {

--- a/internal/adapters/http/server.go
+++ b/internal/adapters/http/server.go
@@ -44,7 +44,7 @@ type Server struct {
 	deps *bootstrap.Dependencies
 }
 
-func (s *Server) Run() {
+func (s *Server) Run() error {
 	gin.SetMode(gin.ReleaseMode)
 
 	engine := gin.Default()
@@ -97,11 +97,14 @@ func (s *Server) Run() {
 		Handler: engine,
 	}
 
-	log.Printf("[INFO] API is running on port: %s\n", s.addr)
+	log.Printf("[INFO] HTTP API is running on port: %s\n", s.addr)
 	log.Printf("[INFO] Pandora Core is fully initialized and ready to accept requests.\n\n")
 	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("[ERROR] Failed to start server: %v", err)
+		log.Printf("[ERROR] Failed to start server: %v\n", err)
+		return err
 	}
+
+	return nil
 }
 
 func NewServer(

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -48,7 +48,7 @@ func getGRPCPort() string {
 	if value, exists := os.LookupEnv("PANDORA_GRPC_PORT"); exists {
 		return value
 	}
-	return "80"
+	return "50051"
 }
 
 func getExposeVersion() bool {


### PR DESCRIPTION
This PR implements the unified application entry point as described in issue #49, enabling the HTTP and gRPC servers to run within the same process.

## Changes:
* Introduced a new cmd/main.go that runs both the HTTP and gRPC servers concurrently using goroutines.
* Reused initialization logic from cmd/http/main.go and cmd/grpc/main.go, now based on the shared global configuration module introduced in #48.

----

Closes #49