### PR TITLE
Add cookies field support to API key validation requests

### DIFF
--- a/internal/adapters/grpc/services/api_key/mapper.go
+++ b/internal/adapters/grpc/services/api_key/mapper.go
@@ -14,6 +14,7 @@ func validateRequestToDomain(req *pb.ValidateRequest) *dto.APIKeyValidate {
 		if req.Request.Metadata != nil {
 			metadata = &dto.RequestIncomingMetadata{
 				Body:            req.Request.Metadata.Body,
+				Cookies:         req.Request.Metadata.Cookies,
 				Headers:         req.Request.Metadata.Headers,
 				QueryParams:     req.Request.Metadata.QueryParams,
 				BodyContentType: enums.RequestBodyContentType(req.Request.Metadata.BodyContentType),

--- a/internal/adapters/grpc/services/api_key/v1/api_key.pb.go
+++ b/internal/adapters/grpc/services/api_key/v1/api_key.pb.go
@@ -26,9 +26,10 @@ const (
 type RequestMetadata struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Body            string                 `protobuf:"bytes,1,opt,name=body,proto3" json:"body,omitempty"`
-	Headers         string                 `protobuf:"bytes,2,opt,name=headers,proto3" json:"headers,omitempty"`
-	QueryParams     string                 `protobuf:"bytes,3,opt,name=query_params,json=queryParams,proto3" json:"query_params,omitempty"`
-	BodyContentType string                 `protobuf:"bytes,4,opt,name=body_content_type,json=bodyContentType,proto3" json:"body_content_type,omitempty"`
+	Cookies         string                 `protobuf:"bytes,2,opt,name=cookies,proto3" json:"cookies,omitempty"`
+	Headers         string                 `protobuf:"bytes,3,opt,name=headers,proto3" json:"headers,omitempty"`
+	QueryParams     string                 `protobuf:"bytes,4,opt,name=query_params,json=queryParams,proto3" json:"query_params,omitempty"`
+	BodyContentType string                 `protobuf:"bytes,5,opt,name=body_content_type,json=bodyContentType,proto3" json:"body_content_type,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -66,6 +67,13 @@ func (*RequestMetadata) Descriptor() ([]byte, []int) {
 func (x *RequestMetadata) GetBody() string {
 	if x != nil {
 		return x.Body
+	}
+	return ""
+}
+
+func (x *RequestMetadata) GetCookies() string {
+	if x != nil {
+		return x.Cookies
 	}
 	return ""
 }
@@ -532,12 +540,13 @@ var File_api_key_v1_api_key_proto protoreflect.FileDescriptor
 const file_api_key_v1_api_key_proto_rawDesc = "" +
 	"\n" +
 	"\x18api_key/v1/api_key.proto\x12\n" +
-	"api_key.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa5\x02\n" +
+	"api_key.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc1\x02\n" +
 	"\x0fRequestMetadata\x12\x12\n" +
 	"\x04body\x18\x01 \x01(\tR\x04body\x12\x18\n" +
-	"\aheaders\x18\x02 \x01(\tR\aheaders\x12!\n" +
-	"\fquery_params\x18\x03 \x01(\tR\vqueryParams\x12\xc0\x01\n" +
-	"\x11body_content_type\x18\x04 \x01(\tB\x93\x01\xbaH\x8f\x01r\x8c\x01R\x0fapplication/xmlR\x10application/jsonR\n" +
+	"\acookies\x18\x02 \x01(\tR\acookies\x12\x18\n" +
+	"\aheaders\x18\x03 \x01(\tR\aheaders\x12!\n" +
+	"\fquery_params\x18\x04 \x01(\tR\vqueryParams\x12\xc2\x01\n" +
+	"\x11body_content_type\x18\x05 \x01(\tB\x95\x01\xbaH\x91\x01r\x8e\x01R\x00R\x0fapplication/xmlR\x10application/jsonR\n" +
 	"text/plainR\ttext/htmlR\x13multipart/form-dataR!application/x-www-form-urlencodedR\x18application/octet-streamR\x0fbodyContentType\"\x91\x02\n" +
 	"\aRequest\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12[\n" +

--- a/internal/adapters/persistence/postgres/request.go
+++ b/internal/adapters/persistence/postgres/request.go
@@ -97,7 +97,6 @@ func (r *RequestRepository) ListByService(
 			COALESCE(unauthorized_reason, ''), created_at
 		FROM request
 		WHERE service_id = $1
-		ORDER BY created_at DESC;
 	`
 
 	args := []any{serviceID}

--- a/internal/adapters/persistence/postgres/request.go
+++ b/internal/adapters/persistence/postgres/request.go
@@ -246,6 +246,7 @@ func (r *RequestRepository) Create(
 	metadata := make(map[string]any)
 	if request.Metadata != nil {
 		metadata["body"] = request.Metadata.Body
+		metadata["cookies"] = request.Metadata.Cookies
 		metadata["headers"] = request.Metadata.Headers
 		metadata["queryParams"] = request.Metadata.QueryParams
 		metadata["bodyContentType"] = request.Metadata.BodyContentType
@@ -343,12 +344,14 @@ func (r *RequestRepository) CreateAsInitialPoint(
 
 	metadata := map[string]any{
 		"body":            "",
+		"cookies":         "",
 		"headers":         "",
 		"queryParams":     "",
 		"bodyContentType": enums.RequestBodyContentTypeNull,
 	}
 	if request.Metadata != nil {
 		metadata["body"] = request.Metadata.Body
+		metadata["cookies"] = request.Metadata.Cookies
 		metadata["headers"] = request.Metadata.Headers
 		metadata["queryParams"] = request.Metadata.QueryParams
 		metadata["bodyContentType"] = request.Metadata.BodyContentType

--- a/internal/app/api_key/validate_consume/use_case.go
+++ b/internal/app/api_key/validate_consume/use_case.go
@@ -42,6 +42,7 @@ func (uc *useCase) Execute(
 	if req.Request.Metadata != nil {
 		requestMetadata = entities.RequestMetadata{
 			QueryParams:     req.Request.Metadata.QueryParams,
+			Cookies:         req.Request.Metadata.Cookies,
 			Headers:         req.Request.Metadata.Headers,
 			Body:            req.Request.Metadata.Body,
 			BodyContentType: req.Request.Metadata.BodyContentType,

--- a/internal/app/api_key/validate_only/use_case.go
+++ b/internal/app/api_key/validate_only/use_case.go
@@ -42,6 +42,7 @@ func (uc *useCase) Execute(
 	if req.Request.Metadata != nil {
 		requestMetadata = entities.RequestMetadata{
 			QueryParams:     req.Request.Metadata.QueryParams,
+			Cookies:         req.Request.Metadata.Cookies,
 			Headers:         req.Request.Metadata.Headers,
 			Body:            req.Request.Metadata.Body,
 			BodyContentType: req.Request.Metadata.BodyContentType,

--- a/internal/domain/dto/request.go
+++ b/internal/domain/dto/request.go
@@ -16,6 +16,7 @@ type RequestFilter struct {
 
 type RequestIncomingMetadata struct {
 	QueryParams     string                       `name:"query_params" validate:"omitempty"`
+	Cookies         string                       `name:"cookies" validate:"omitempty"`
 	Headers         string                       `name:"headers" validate:"omitempty"`
 	Body            string                       `name:"body" validate:"omitempty"`
 	BodyContentType enums.RequestBodyContentType `name:"body_content_type" validate:"omitempty,enums=application/xml application/json text/plain text/html multipart/form-data application/x-www-form-urlencoded application/octet-stream"`
@@ -79,6 +80,7 @@ type RequestResponse struct {
 type RequestDetailsReponse struct {
 	Body            string                       `name:"body"`
 	BodyContentType enums.RequestBodyContentType `name:"body_content_type"`
+	Cookies         string                       `name:"cookies"`
 	Headers         string                       `name:"headers"`
 	QueryParams     string                       `name:"query_params"`
 }

--- a/internal/domain/entities/request.go
+++ b/internal/domain/entities/request.go
@@ -9,6 +9,7 @@ import (
 type RequestMetadata struct {
 	Body            string
 	BodyContentType enums.RequestBodyContentType
+	Cookies         string
 	Headers         string
 	QueryParams     string
 }


### PR DESCRIPTION
 ## Summary
  - Add cookies field to RequestMetadata proto definition support
  - Update proto submodule to include cookies field and allow empty
  body_content_type
  - Implement cookies field handling across all layers (entities, DTOs,
  gRPC mappers, use cases)
  - Ensure cookies are stored in database metadata JSONB field

  ## Changes
  - Updated proto submodule to latest version with cookies field
  - Regenerated gRPC code with buf generate
  - Added Cookies field to RequestMetadata entity and DTOs
  - Updated gRPC mapper to handle cookies from proto to domain layer
  - Modified API key validation use cases (validate_only and 
  validate_consume) to process cookies
  - Enhanced repository layer to store/retrieve cookies in metadata JSONB